### PR TITLE
Update luau code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxts/roact-rodux",
-	"version": "0.2.2-ts.4",
+	"version": "0.2.2-ts.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,50 +1,8 @@
 {
 	"name": "@rbxts/roact-rodux",
-	"version": "0.2.2-ts.3",
-	"lockfileVersion": 2,
+	"version": "0.2.2-ts.4",
+	"lockfileVersion": 1,
 	"requires": true,
-	"packages": {
-		"": {
-			"name": "@rbxts/roact-rodux",
-			"version": "0.2.2-ts.3",
-			"license": "ISC",
-			"devDependencies": {
-				"@rbxts/compiler-types": "1.1.1-types.5",
-				"@rbxts/roact": "1.4.0-ts.0",
-				"@rbxts/rodux": "3.0.0-ts.3",
-				"@rbxts/types": "^1.0.503"
-			},
-			"peerDependencies": {
-				"@rbxts/roact": "1.4.0-ts.0",
-				"@rbxts/rodux": "3.0.0-ts.3",
-				"@rbxts/types": "^1.0.503"
-			}
-		},
-		"node_modules/@rbxts/compiler-types": {
-			"version": "1.1.1-types.5",
-			"resolved": "https://registry.npmjs.org/@rbxts/compiler-types/-/compiler-types-1.1.1-types.5.tgz",
-			"integrity": "sha512-xnFLpXXYgihr5lbjeHOvAupEAJRD2yjgRpg6g4MDp+WzcIFdRGVxaIL40o4CAOvkEH5EjtTO/krDPz4NAJHfdA==",
-			"dev": true
-		},
-		"node_modules/@rbxts/roact": {
-			"version": "1.4.0-ts.0",
-			"resolved": "https://registry.npmjs.org/@rbxts/roact/-/roact-1.4.0-ts.0.tgz",
-			"integrity": "sha512-n+ORC8E9ql59SkdYWBmWxgv9OAVN+2WztOmq+te0Yd4hYJqzB24CgrUmMUn96BwEww7t2MCWzxF7xMKcLPYVdw==",
-			"dev": true
-		},
-		"node_modules/@rbxts/rodux": {
-			"version": "3.0.0-ts.3",
-			"resolved": "https://registry.npmjs.org/@rbxts/rodux/-/rodux-3.0.0-ts.3.tgz",
-			"integrity": "sha512-LrLowiF1YL5U+lQheCNMo8sbrSEoZAIlVFOGB7Edjein5TtZAeNgyJrhY5yFH5gAfJQzFRnZWVOxWFaMlD0GRg==",
-			"dev": true
-		},
-		"node_modules/@rbxts/types": {
-			"version": "1.0.503",
-			"resolved": "https://registry.npmjs.org/@rbxts/types/-/types-1.0.503.tgz",
-			"integrity": "sha512-6HIiDSjJt0USUlelhNUqFmycLVEmtKv2GbcCNnCZdgmDXZVp8y9dlsUWXZscYm+J4mSqnh8OcqWnmnVCprVRZw==",
-			"dev": true
-		}
-	},
 	"dependencies": {
 		"@rbxts/compiler-types": {
 			"version": "1.1.1-types.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxts/roact-rodux",
-	"version": "0.2.2-ts.4",
+	"version": "0.2.2-ts.5",
 	"description": "",
 	"scripts": {},
 	"keywords": [],

--- a/src/StoreContext.lua
+++ b/src/StoreContext.lua
@@ -1,0 +1,6 @@
+local nodeModules = script.Parent.Parent.Parent
+local Roact = require(nodeModules.roact.src)
+
+local StoreContext = Roact.createContext()
+
+return StoreContext

--- a/src/StoreProvider.lua
+++ b/src/StoreProvider.lua
@@ -1,22 +1,28 @@
 local nodeModules = script.Parent.Parent.Parent
 local Roact = require(nodeModules.roact.src)
 
-local storeKey = require(script.Parent.storeKey)
+local StoreContext = require(script.Parent.StoreContext)
 
 local StoreProvider = Roact.Component:extend("StoreProvider")
 
-function StoreProvider:init(props)
+function StoreProvider.validateProps(props)
 	local store = props.store
-
 	if store == nil then
-		error("Error initializing StoreProvider. Expected a `store` prop to be a Rodux store.")
+		return false, "Error initializing StoreProvider. Expected a `store` prop to be a Rodux store."
 	end
+	return true
+end
 
-	self._context[storeKey] = store
+function StoreProvider:init(props)
+	self.store = props.store
 end
 
 function StoreProvider:render()
-	return Roact.createFragment(self.props[Roact.Children])
+	return Roact.createElement(StoreContext.Provider, {
+		value = self.store,
+	}, Roact.oneChild(
+		self.props[Roact.Children]
+	))
 end
 
 return StoreProvider

--- a/src/getStore.lua
+++ b/src/getStore.lua
@@ -1,7 +1,0 @@
-local storeKey = require(script.Parent.storeKey)
-
-local function getStore(componentInstance)
-	return componentInstance._context[storeKey]
-end
-
-return getStore

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,10 +1,8 @@
 local StoreProvider = require(script.StoreProvider)
 local connect = require(script.connect)
-local getStore = require(script.getStore)
 
 return {
 	StoreProvider = StoreProvider,
 	connect = connect,
-	UNSTABLE_getStore = getStore,
 	UNSTABLE_connect2 = connect,
 }

--- a/src/storeKey.lua
+++ b/src/storeKey.lua
@@ -1,3 +1,0 @@
-local Symbol = require(script.Parent.Symbol)
-
-return Symbol.named("RoduxStore")


### PR DESCRIPTION
This will update the source code to its latest version, which brings up the new Context API as well. I am currently creating some hooks for Rodux, and those relies on `useContext` in order to get the store value that was passed into the `StoreProvider`. However, the former won't work with the legacy context, since it's not a Roact component.